### PR TITLE
update dependencies

### DIFF
--- a/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj
+++ b/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj
@@ -10,12 +10,12 @@
 
     <ItemGroup>
       <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-      <PackageReference Include="Meziantou.Analyzer" Version="1.0.698">
+      <PackageReference Include="Meziantou.Analyzer" Version="2.0.212">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Optional" Version="4.0.0" />
-      <PackageReference Include="SkiaSharp" Version="3.116.0" />
+      <PackageReference Include="SkiaSharp" Version="3.119.0" />
     </ItemGroup>
 
 </Project>

--- a/HocrEditor/HocrEditor.csproj
+++ b/HocrEditor/HocrEditor.csproj
@@ -28,22 +28,22 @@
     <ItemGroup>
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="gong-wpf-dragdrop" Version="4.0.0" />
-        <PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
-        <PackageReference Include="icu.net" Version="3.0.0" />
+        <PackageReference Include="HtmlAgilityPack" Version="1.12.2" />
+        <PackageReference Include="icu.net" Version="3.0.1" />
         <PackageReference Include="Icu4c.Win.Full.Lib" Version="59.1.15" />
         <PackageReference Include="Iso639" Version="1.0.0" />
-        <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-        <PackageReference Include="Meziantou.Analyzer" Version="2.0.182">
+        <PackageReference Include="JetBrains.Annotations" Version="2025.2.0" />
+        <PackageReference Include="Meziantou.Analyzer" Version="2.0.212">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.8" />
         <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
         <PackageReference Include="Optional" Version="4.0.0" />
         <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
-        <PackageReference Include="SkiaSharp" Version="3.116.1" />
-        <PackageReference Include="SkiaSharp.Views.WPF" Version="3.116.1" />
-        <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
+        <PackageReference Include="SkiaSharp" Version="3.119.0" />
+        <PackageReference Include="SkiaSharp.Views.WPF" Version="3.119.0" />
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/scripts/update-dependencies.sh
+++ b/scripts/update-dependencies.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# update dependencies of a dotnet project
+# https://stackoverflow.com/a/52387851/10440128
+
+# fix: error MSB4019: The imported project ".../Microsoft.NET.Sdk.WindowsDesktop.targets" was not found.
+# Confirm that the expression in the Import declaration "$(AfterMicrosoftNETSdkTargets)",
+# which evaluated to ";.../Microsoft.NET.Sdk.WindowsDesktop.targets", is correct, and that the file exists on disk.
+# Unable to create dependency graph file for project './HocrEditor/HocrEditor.csproj'. Cannot add package reference.
+# this is dotnet 10.0.100-preview.7.25380.108 for windows x64
+# https://dotnet.microsoft.com/en-us/download/dotnet/10.0
+function dotnet() { wine ~/".wine/drive_c/Program Files/dotnet/dotnet.exe" "$@"; }
+
+set -eux
+regex='PackageReference Include="([^"]*)" Version="([^"]*)"'
+find . -name "*.*proj" | while read proj
+do
+  while read line
+  do
+    if [[ $line =~ $regex ]]
+    then
+      name="${BASH_REMATCH[1]}"
+      version="${BASH_REMATCH[2]}"
+      if [[ $version != *-* ]]
+      then
+        dotnet add $proj package $name || true
+      fi
+    fi
+  done < $proj
+done


### PR DESCRIPTION
i wanted to run this on linux
but the dependencies were so old, they required dotnet6.0 on runtime
but there is no [dotnet6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0/runtime) desktop runtime for linux

i managed to update dependencies with `wine dotnet.exe`
but now the build is failing

im building this with [hocr-editor-cs.nix](https://github.com/milahu/nur-packages/blob/master/pkgs/tools/misc/hocr-editor-cs/default.nix)

probably noone will fix this...

<details>
<summary>
build.log
</summary>

```
Running phase: buildPhase
Executing dotnetBuildHook
/build/HocrEditor/HocrEditor/HocrEditor.csproj : warning NU1701: Package 'OpenTK 3.3.1' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor/HocrEditor.csproj : warning NU1701: Package 'OpenTK.GLWpfControl 3.3.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor/HocrEditor.csproj : warning NU1701: Package 'SkiaSharp.Views.WPF 3.119.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor.Tesseract/TesseractService.cs(24,50): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.OpenSubKey(string)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/build/HocrEditor/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj]
/build/HocrEditor/HocrEditor.Tesseract/TesseractService.cs(23,50): warning CA1416: This call site is reachable on all platforms. 'Registry.CurrentUser' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/build/HocrEditor/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj]
/build/HocrEditor/HocrEditor.Tesseract/TesseractService.cs(26,42): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.GetValue(string?)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/build/HocrEditor/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj]
/build/HocrEditor/HocrEditor.Tesseract/TesseractService.cs(24,50): warning CA1416: This call site is reachable on all platforms. 'Registry.LocalMachine' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/build/HocrEditor/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj]
/build/HocrEditor/HocrEditor.Tesseract/TesseractService.cs(23,50): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.OpenSubKey(string)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/build/HocrEditor/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj]
  HocrEditor.Tesseract -> /build/HocrEditor/HocrEditor.Tesseract/bin/Release/net9.0/HocrEditor.Tesseract.dll
/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj : warning NU1701: Package 'OpenTK 3.3.1' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj : warning NU1701: Package 'OpenTK.GLWpfControl 3.3.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj : warning NU1701: Package 'SkiaSharp.Views.WPF 3.119.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor/Controls/LanguagesDropdownButton.xaml(41,63): error CS1061: 'LanguagesButton' does not contain a definition for 'Popup_OnClosed' and no accessible extension method 'Popup_OnClosed' accepting a first argument of type 'LanguagesButton' could be found (are you missing a using directive or an assembly reference?) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Behaviors/BringTreeViewItemIntoViewBehavior.cs(138,41): warning CS8600: Converting null literal or possible null value to non-nullable type. [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Behaviors/BringTreeViewItemIntoViewBehavior.cs(158,33): warning CS8602: Dereference of a possibly null reference. [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Behaviors/BringTreeViewItemIntoViewBehavior.cs(164,25): warning CS8602: Dereference of a possibly null reference. [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/ViewModels/Filters/IImageFilter.cs(9,27): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable. [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/LanguagesDropdownButton.xaml.cs(37,9): error CS0103: The name 'InitializeComponent' does not exist in the current context [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/LanguagesDropdownButton.xaml.cs(42,16): error CS0117: 'Button' does not contain a definition for 'IsChecked' [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/LanguagesDropdownButton.xaml.cs(47,9): error CS0103: The name 'Popup' does not exist in the current context [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/CreateNodeCommand.cs(53,16): warning MA0026: TODO Avoid this horrible bit somehow. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/MergeNodesCommand.cs(31,16): warning MA0026: TODO Show error. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/OcrRegionCommand.cs(137,28): warning MA0026: TODO Improve error handling. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/PasteCommand.cs(50,16): warning MA0026: TODO Any way to keep moving it down as more copies are added? (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/UndoRedo/PageRemoveNodesCommand.cs(71,16): warning MA0026: TODO Should this also be cleaned? (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentCanvas/DocumentCanvas.xaml.cs(251,12): warning MA0026: TODO Figure out proper disposal event. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentCanvas/RegionToolBase.cs(333,12): warning MA0026: TODO Support for multiple selection. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentCanvas/RegionToolBase.cs(578,12): warning MA0026: TODO Mac support? (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentTreeView.xaml.cs(183,12): warning MA0026: TODO Is it possible to avoid this call? (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/ZoomPanControl.xaml.cs(196,12): warning MA0026: TODO Clamping to the exact zoom limits is not as straightforward as setting the scale, as the translation (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/ZoomPanControl.xaml.cs(218,8): warning MA0026: TODO Make this happen only after first render somehow. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/AsyncCommandBase.cs(12,23): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Core/RangeObservableCollection.cs(659,11): warning MA0026: TODO should have really been a local method inside ReplaceRange(int index, int count, IEnumerable<T> collection, IEqualityComparer<T> comparer), (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Services/HocrWriter.cs(121,85): warning MA0026: TODO Find a better ranking method. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/ViewModels/AdjustmentFilters.cs(30,8): warning MA0026: TODO Extract? (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(11,17): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrDocument.cs(35,16): warning MA0016: Prefer using collection abstraction instead of implementation (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0016.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrDocument.cs(41,16): warning MA0016: Prefer using collection abstraction instead of implementation (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0016.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/ViewModels/MainWindowViewModel.cs(183,16): warning MA0026: TODO Figure out syncing and using the model. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Core/ObservableHashSet.cs(492,23): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNode.cs(95,16): warning MA0016: Prefer using collection abstraction instead of implementation (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0016.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(55,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(77,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(17,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(99,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(166,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(188,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(144,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(210,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(265,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(232,26): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Helpers/SKExtensions.cs(7,21): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Converters/ContentEmptyConverter.cs(31,9): warning MA0025: Implement the functionality (or raise NotSupportedException or PlatformNotSupportedException) (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0025.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Behaviors/BringTreeViewItemIntoViewBehavior.cs(81,9): warning MA0134: Observe result of async calls (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Core/RangeObservableCollection.cs(78,42): warning MA0016: Prefer using collection abstraction instead of implementation (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0016.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/LazyLoadImage.cs(45,9): warning MA0134: Observe result of async calls (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/EditableTextBlock.xaml.cs(73,13): warning MA0134: Observe result of async calls (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentCanvas/DocumentCanvas.xaml.cs(883,44): warning MA0134: Observe result of async calls (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentCanvas/DocumentCanvas.xaml.cs(851,37): warning MA0134: Observe result of async calls (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
  HocrEditor.Tesseract -> /build/HocrEditor/HocrEditor.Tesseract/bin/Release/net9.0/HocrEditor.Tesseract.dll

Build FAILED.

/build/HocrEditor/HocrEditor/HocrEditor.csproj : warning NU1701: Package 'OpenTK 3.3.1' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor/HocrEditor.csproj : warning NU1701: Package 'OpenTK.GLWpfControl 3.3.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor/HocrEditor.csproj : warning NU1701: Package 'SkiaSharp.Views.WPF 3.119.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor.Tesseract/TesseractService.cs(24,50): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.OpenSubKey(string)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/build/HocrEditor/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj]
/build/HocrEditor/HocrEditor.Tesseract/TesseractService.cs(23,50): warning CA1416: This call site is reachable on all platforms. 'Registry.CurrentUser' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/build/HocrEditor/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj]
/build/HocrEditor/HocrEditor.Tesseract/TesseractService.cs(26,42): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.GetValue(string?)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/build/HocrEditor/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj]
/build/HocrEditor/HocrEditor.Tesseract/TesseractService.cs(24,50): warning CA1416: This call site is reachable on all platforms. 'Registry.LocalMachine' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/build/HocrEditor/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj]
/build/HocrEditor/HocrEditor.Tesseract/TesseractService.cs(23,50): warning CA1416: This call site is reachable on all platforms. 'RegistryKey.OpenSubKey(string)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416) [/build/HocrEditor/HocrEditor.Tesseract/HocrEditor.Tesseract.csproj]
/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj : warning NU1701: Package 'OpenTK 3.3.1' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj : warning NU1701: Package 'OpenTK.GLWpfControl 3.3.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj : warning NU1701: Package 'SkiaSharp.Views.WPF 3.119.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net9.0-windows7.0'. This package may not be fully compatible with your project.
/build/HocrEditor/HocrEditor/Behaviors/BringTreeViewItemIntoViewBehavior.cs(138,41): warning CS8600: Converting null literal or possible null value to non-nullable type. [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Behaviors/BringTreeViewItemIntoViewBehavior.cs(158,33): warning CS8602: Dereference of a possibly null reference. [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Behaviors/BringTreeViewItemIntoViewBehavior.cs(164,25): warning CS8602: Dereference of a possibly null reference. [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/ViewModels/Filters/IImageFilter.cs(9,27): warning CS8618: Non-nullable property 'Name' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable. [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/CreateNodeCommand.cs(53,16): warning MA0026: TODO Avoid this horrible bit somehow. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/MergeNodesCommand.cs(31,16): warning MA0026: TODO Show error. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/OcrRegionCommand.cs(137,28): warning MA0026: TODO Improve error handling. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/PasteCommand.cs(50,16): warning MA0026: TODO Any way to keep moving it down as more copies are added? (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/UndoRedo/PageRemoveNodesCommand.cs(71,16): warning MA0026: TODO Should this also be cleaned? (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentCanvas/DocumentCanvas.xaml.cs(251,12): warning MA0026: TODO Figure out proper disposal event. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentCanvas/RegionToolBase.cs(333,12): warning MA0026: TODO Support for multiple selection. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentCanvas/RegionToolBase.cs(578,12): warning MA0026: TODO Mac support? (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentTreeView.xaml.cs(183,12): warning MA0026: TODO Is it possible to avoid this call? (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/ZoomPanControl.xaml.cs(196,12): warning MA0026: TODO Clamping to the exact zoom limits is not as straightforward as setting the scale, as the translation (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/ZoomPanControl.xaml.cs(218,8): warning MA0026: TODO Make this happen only after first render somehow. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Commands/AsyncCommandBase.cs(12,23): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Core/RangeObservableCollection.cs(659,11): warning MA0026: TODO should have really been a local method inside ReplaceRange(int index, int count, IEnumerable<T> collection, IEqualityComparer<T> comparer), (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Services/HocrWriter.cs(121,85): warning MA0026: TODO Find a better ranking method. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/ViewModels/AdjustmentFilters.cs(30,8): warning MA0026: TODO Extract? (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(11,17): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrDocument.cs(35,16): warning MA0016: Prefer using collection abstraction instead of implementation (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0016.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrDocument.cs(41,16): warning MA0016: Prefer using collection abstraction instead of implementation (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0016.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/ViewModels/MainWindowViewModel.cs(183,16): warning MA0026: TODO Figure out syncing and using the model. (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0026.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Core/ObservableHashSet.cs(492,23): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNode.cs(95,16): warning MA0016: Prefer using collection abstraction instead of implementation (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0016.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(55,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(77,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(17,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(99,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(166,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(188,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(144,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(210,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(265,19): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Models/HocrNodes.cs(232,26): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Helpers/SKExtensions.cs(7,21): warning MA0048: File name must match type name (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0048.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Converters/ContentEmptyConverter.cs(31,9): warning MA0025: Implement the functionality (or raise NotSupportedException or PlatformNotSupportedException) (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0025.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Behaviors/BringTreeViewItemIntoViewBehavior.cs(81,9): warning MA0134: Observe result of async calls (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Core/RangeObservableCollection.cs(78,42): warning MA0016: Prefer using collection abstraction instead of implementation (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0016.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/LazyLoadImage.cs(45,9): warning MA0134: Observe result of async calls (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/EditableTextBlock.xaml.cs(73,13): warning MA0134: Observe result of async calls (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentCanvas/DocumentCanvas.xaml.cs(883,44): warning MA0134: Observe result of async calls (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/DocumentCanvas/DocumentCanvas.xaml.cs(851,37): warning MA0134: Observe result of async calls (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0134.md) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/LanguagesDropdownButton.xaml(41,63): error CS1061: 'LanguagesButton' does not contain a definition for 'Popup_OnClosed' and no accessible extension method 'Popup_OnClosed' accepting a first argument of type 'LanguagesButton' could be found (are you missing a using directive or an assembly reference?) [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/LanguagesDropdownButton.xaml.cs(37,9): error CS0103: The name 'InitializeComponent' does not exist in the current context [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/LanguagesDropdownButton.xaml.cs(42,16): error CS0117: 'Button' does not contain a definition for 'IsChecked' [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
/build/HocrEditor/HocrEditor/Controls/LanguagesDropdownButton.xaml.cs(47,9): error CS0103: The name 'Popup' does not exist in the current context [/build/HocrEditor/HocrEditor/HocrEditor_cn3fhpi2_wpftmp.csproj]
    54 Warning(s)
    4 Error(s)
```

</details>

